### PR TITLE
Add admin-specific report metadata fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,11 @@ ALLOWED_EXTS = set(os.getenv("ALLOWED_EXTS", ",".join(DEFAULT_ALLOWED_EXTS)).spl
 MAX_MB = int(os.getenv("UPLOAD_MAX_MB", "25"))
 MAX_CONTENT_LENGTH = MAX_MB * 1024 * 1024
 
+STATUS_OPTIONS = ["Nuevo", "En revisión", "Completado", "Cerrado"]
+PRIORITY_OPTIONS = ["Baja", "Media", "Alta"]
+DEFAULT_STATUS = STATUS_OPTIONS[0]
+DEFAULT_PRIORITY = PRIORITY_OPTIONS[1]
+
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", os.urandom(24).hex())
 app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{BASE_DIR / 'report_portal.db'}"
@@ -52,6 +57,11 @@ class Report(db.Model):
     description = db.Column(db.Text, nullable=False)
     filename = db.Column(db.String(255), nullable=True)  # stored name on disk
     original_filename = db.Column(db.String(255), nullable=True)  # original name
+    category = db.Column(db.String(120), nullable=True)
+    status = db.Column(db.String(50), nullable=False, default=DEFAULT_STATUS)
+    priority = db.Column(db.String(20), nullable=False, default=DEFAULT_PRIORITY)
+    assigned_to = db.Column(db.String(120), nullable=True)
+    notes = db.Column(db.Text, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     user = db.relationship("User", backref=db.backref("reports", lazy=True))
@@ -115,6 +125,8 @@ def submit_report():
         title = request.form.get("title","").strip()
         description = request.form.get("description","").strip()
         file = request.files.get("file")
+        category = request.form.get("category", "").strip() if current_user.is_admin else ""
+        notes = request.form.get("notes", "").strip() if current_user.is_admin else ""
         if not title or not description:
             flash("Título y descripción son obligatorios.", "warning")
             return redirect(request.url)
@@ -131,18 +143,42 @@ def submit_report():
             file.save(UPLOAD_FOLDER / stored)
             saved_name = stored
 
+        status_value = DEFAULT_STATUS
+        priority_value = DEFAULT_PRIORITY
+        assigned_to = None
+        if current_user.is_admin:
+            status_raw = request.form.get("status", "").strip()
+            priority_raw = request.form.get("priority", "").strip()
+            assigned_raw = request.form.get("assigned_to", "").strip()
+            if status_raw in STATUS_OPTIONS:
+                status_value = status_raw
+            if priority_raw in PRIORITY_OPTIONS:
+                priority_value = priority_raw
+            assigned_to = assigned_raw or None
+
         rep = Report(
             title=title,
             description=description,
             filename=saved_name,
             original_filename=original_name,
+            category=(category or None),
+            status=status_value,
+            priority=priority_value,
+            assigned_to=assigned_to,
+            notes=(notes or None),
             user_id=current_user.id
         )
         db.session.add(rep)
         db.session.commit()
         flash("Reporte enviado.", "success")
         return redirect(url_for("index"))
-    return render_template("submit_report.html", allowed_exts=", ".join(sorted(ALLOWED_EXTS)), max_mb=MAX_MB)
+    return render_template(
+        "submit_report.html",
+        allowed_exts=", ".join(sorted(ALLOWED_EXTS)),
+        max_mb=MAX_MB,
+        status_choices=STATUS_OPTIONS,
+        priority_choices=PRIORITY_OPTIONS,
+    )
 
 @app.route("/reports/<int:report_id>")
 @login_required

--- a/static/styles.css
+++ b/static/styles.css
@@ -12,10 +12,11 @@ h1 { font-size: 28px; margin: 8px 0 16px; }
 
 .card { background:var(--card); border:1px solid rgba(255,255,255,.08); border-radius:16px; padding:16px; box-shadow: 0 10px 30px rgba(0,0,0,.25); }
 label { display:block; margin-bottom:12px; font-weight:600; }
-input[type="text"], input[type="password"], textarea, input[type="file"] {
+input[type="text"], input[type="password"], textarea, input[type="file"], select {
   width:100%; background:#0b1226; color:var(--text); border:1px solid rgba(255,255,255,.15);
   border-radius:12px; padding:10px 12px; outline:none;
 }
+select { appearance:none; }
 .checkbox { display:flex; align-items:center; gap:8px; font-weight:600; }
 .muted { color: var(--muted); }
 
@@ -36,3 +37,7 @@ input[type="text"], input[type="password"], textarea, input[type="file"] {
 .list-item:hover { background: rgba(255,255,255,.04); }
 .list-title { font-weight:700; }
 .list-meta { color:var(--muted); font-size: 12px; margin-top:4px; }
+
+.report-details { display:grid; grid-template-columns: minmax(120px, 160px) 1fr; gap:8px 16px; margin:16px 0 0; }
+.report-details dt { font-weight:700; color:var(--muted); }
+.report-details dd { margin:0; }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,7 +9,8 @@
       {% for r in reports %}
         <a class="list-item" href="{{ url_for('view_report', report_id=r.id) }}">
           <div class="list-title">{{ r.title }}</div>
-          <div class="list-meta">Por {{ r.user.full_name }} • {{ r.created_at.strftime('%Y-%m-%d %H:%M') }}</div>
+          <div class="list-meta">Por {{ r.user.full_name }} • {{ r.created_at.strftime('%Y-%m-%d %H:%M') }}{% if r.category %} • Categoría: {{ r.category }}{% endif %}</div>
+          <div class="list-meta">Estado: <strong>{{ r.status }}</strong> • Prioridad: <strong>{{ r.priority }}</strong>{% if r.assigned_to %} • Asignado a: {{ r.assigned_to }}{% endif %}</div>
         </a>
       {% endfor %}
     </div>

--- a/templates/submit_report.html
+++ b/templates/submit_report.html
@@ -9,6 +9,31 @@
     <label>Descripción
       <textarea name="description" rows="6" required></textarea>
     </label>
+    {% if current_user.is_admin %}
+      <label>Categoría
+        <input type="text" name="category" placeholder="Ej. Finanzas, Soporte">
+      </label>
+      <label>Estado
+        <select name="status">
+          {% for status in status_choices %}
+            <option value="{{ status }}">{{ status }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Prioridad
+        <select name="priority">
+          {% for priority in priority_choices %}
+            <option value="{{ priority }}" {% if priority == 'Media' %}selected{% endif %}>{{ priority }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Asignado a
+        <input type="text" name="assigned_to" placeholder="Nombre del responsable">
+      </label>
+      <label>Notas internas
+        <textarea name="notes" rows="4" placeholder="Información adicional para el equipo"></textarea>
+      </label>
+    {% endif %}
     <label>Archivo adjunto (opcional)
       <input type="file" name="file" >
       <small>Permitidos: {{ allowed_exts }}. Máx {{ max_mb }}MB.</small>

--- a/templates/view_report.html
+++ b/templates/view_report.html
@@ -4,11 +4,29 @@
   <h1>{{ report.title }}</h1>
   <p class="muted">Creado: {{ report.created_at.strftime('%Y-%m-%d %H:%M') }} por {{ report.user.full_name }}</p>
   <article class="card">
+    <h2>Descripción</h2>
     <p>{{ report.description|e }}</p>
     {% if report.filename %}
       <p><a class="btn" href="{{ url_for('download_file', filename=report.filename) }}">Descargar adjunto ({{ report.original_filename }})</a></p>
     {% else %}
       <p class="muted">Sin adjunto.</p>
+    {% endif %}
+  </article>
+  <article class="card">
+    <h2>Detalles</h2>
+    <dl class="report-details">
+      <dt>Categoría</dt>
+      <dd>{{ report.category or 'No especificada' }}</dd>
+      <dt>Estado</dt>
+      <dd>{{ report.status }}</dd>
+      <dt>Prioridad</dt>
+      <dd>{{ report.priority }}</dd>
+      <dt>Asignado a</dt>
+      <dd>{{ report.assigned_to or 'Sin asignar' }}</dd>
+    </dl>
+    {% if report.notes and current_user.is_admin %}
+      <h3>Notas internas</h3>
+      <p>{{ report.notes }}</p>
     {% endif %}
   </article>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add metadata columns to reports so administrators can capture category, status, priority, assignment and notes
- expose the new metadata fields on the submission form for admins and surface the details in the dashboard and report view
- tweak styles to support select inputs and a structured detail layout

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e035fceee883308b80d77a211da08d