### PR TITLE
Allow all users to manage report metadata

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -12,10 +12,11 @@ h1 { font-size: 28px; margin: 8px 0 16px; }
 
 .card { background:var(--card); border:1px solid rgba(255,255,255,.08); border-radius:16px; padding:16px; box-shadow: 0 10px 30px rgba(0,0,0,.25); }
 label { display:block; margin-bottom:12px; font-weight:600; }
-input[type="text"], input[type="password"], textarea, input[type="file"] {
+input[type="text"], input[type="password"], textarea, input[type="file"], select {
   width:100%; background:#0b1226; color:var(--text); border:1px solid rgba(255,255,255,.15);
   border-radius:12px; padding:10px 12px; outline:none;
 }
+select { appearance:none; }
 .checkbox { display:flex; align-items:center; gap:8px; font-weight:600; }
 .muted { color: var(--muted); }
 
@@ -36,3 +37,7 @@ input[type="text"], input[type="password"], textarea, input[type="file"] {
 .list-item:hover { background: rgba(255,255,255,.04); }
 .list-title { font-weight:700; }
 .list-meta { color:var(--muted); font-size: 12px; margin-top:4px; }
+
+.report-details { display:grid; grid-template-columns: minmax(120px, 160px) 1fr; gap:8px 16px; margin:16px 0 0; }
+.report-details dt { font-weight:700; color:var(--muted); }
+.report-details dd { margin:0; }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,7 +9,8 @@
       {% for r in reports %}
         <a class="list-item" href="{{ url_for('view_report', report_id=r.id) }}">
           <div class="list-title">{{ r.title }}</div>
-          <div class="list-meta">Por {{ r.user.full_name }} • {{ r.created_at.strftime('%Y-%m-%d %H:%M') }}</div>
+          <div class="list-meta">Por {{ r.user.full_name }} • {{ r.created_at.strftime('%Y-%m-%d %H:%M') }}{% if r.category %} • Categoría: {{ r.category }}{% endif %}</div>
+          <div class="list-meta">Estado: <strong>{{ r.status }}</strong> • Prioridad: <strong>{{ r.priority }}</strong>{% if r.assigned_to %} • Asignado a: {{ r.assigned_to }}{% endif %}</div>
         </a>
       {% endfor %}
     </div>

--- a/templates/submit_report.html
+++ b/templates/submit_report.html
@@ -9,6 +9,29 @@
     <label>Descripción
       <textarea name="description" rows="6" required></textarea>
     </label>
+    <label>Categoría
+      <input type="text" name="category" placeholder="Ej. Finanzas, Soporte">
+    </label>
+    <label>Estado
+      <select name="status">
+        {% for status in status_choices %}
+          <option value="{{ status }}" {% if status == default_status %}selected{% endif %}>{{ status }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Prioridad
+      <select name="priority">
+        {% for priority in priority_choices %}
+          <option value="{{ priority }}" {% if priority == default_priority %}selected{% endif %}>{{ priority }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Asignado a
+      <input type="text" name="assigned_to" placeholder="Nombre del responsable">
+    </label>
+    <label>Notas
+      <textarea name="notes" rows="4" placeholder="Información adicional para el equipo"></textarea>
+    </label>
     <label>Archivo adjunto (opcional)
       <input type="file" name="file" >
       <small>Permitidos: {{ allowed_exts }}. Máx {{ max_mb }}MB.</small>

--- a/templates/view_report.html
+++ b/templates/view_report.html
@@ -4,11 +4,27 @@
   <h1>{{ report.title }}</h1>
   <p class="muted">Creado: {{ report.created_at.strftime('%Y-%m-%d %H:%M') }} por {{ report.user.full_name }}</p>
   <article class="card">
+    <h2>Descripción</h2>
     <p>{{ report.description|e }}</p>
     {% if report.filename %}
       <p><a class="btn" href="{{ url_for('download_file', filename=report.filename) }}">Descargar adjunto ({{ report.original_filename }})</a></p>
     {% else %}
       <p class="muted">Sin adjunto.</p>
     {% endif %}
+  </article>
+  <article class="card">
+    <h2>Detalles</h2>
+    <dl class="report-details">
+      <dt>Categoría</dt>
+      <dd>{{ report.category or 'No especificada' }}</dd>
+      <dt>Estado</dt>
+      <dd>{{ report.status }}</dd>
+      <dt>Prioridad</dt>
+      <dd>{{ report.priority }}</dd>
+      <dt>Asignado a</dt>
+      <dd>{{ report.assigned_to or 'Sin asignar' }}</dd>
+      <dt>Notas</dt>
+      <dd>{{ report.notes or 'Sin notas adicionales' }}</dd>
+    </dl>
   </article>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add metadata columns to reports so administrators can capture category, status, priority, assignment and notes
- expose the metadata fields on the submission form for all users and surface the details in the dashboard and report view
- tweak styles to support select inputs and a structured detail layout

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e035fceee883308b80d77a211da08d